### PR TITLE
Add txwait option to sendTransaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ const tx = {
 };
 
 const signer = new IntmaxWalletSigner();
-const receipt = await signer.sendTransaction(tx, false);
+const receipt = await signer.sendTransaction(tx);
 ```
 
 #### Sign message with intmaxWallet signer

--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ const serializedSignature = await signer.signTransaction(tx);
 
 Signer can sign and send transactions. You will receive a receipt.
 
+> If passing `txwait` as the second argument allows the intmaxwallet to control whether to wait for the transaction to be mined.
+
 ```ts
 import { IntmaxWalletSigner } from "webmax";
 
@@ -86,7 +88,7 @@ const tx = {
 };
 
 const signer = new IntmaxWalletSigner();
-const receipt = await signer.sendTransaction(tx);
+const receipt = await signer.sendTransaction(tx, false);
 ```
 
 #### Sign message with intmaxWallet signer

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -37,6 +37,7 @@ export type IntmaxWalletMessageParams = {
 
 export type IntmaxWalletInteractParams = {
   type: SignerType;
+  txWait?: boolean;
   data?:
     | TransactionRequest
     | IntmaxWalletMessageParams

--- a/src/signer.ts
+++ b/src/signer.ts
@@ -84,10 +84,14 @@ export class IntmaxWalletSigner {
     return serializedSignature;
   }
 
-  async sendTransaction(transaction: TransactionRequest): Promise<TransactionReceipt> {
+  async sendTransaction(
+    transaction: TransactionRequest,
+    txWait = true
+  ): Promise<TransactionReceipt> {
     const params = {
       type: signerType.sendTransaction,
       data: transaction,
+      txWait,
     };
 
     const receipt = await this.interactIntmaxWallet<TransactionReceipt>(


### PR DESCRIPTION
## Describe your changes

Passing `txwait` as the second argument allows the intmaxwallet to control whether to wait for the transaction to be mined.

## Issue ticket number and link

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics?
- [ ] Will this be part of a product update? If yes, please write one phrase about this update.
